### PR TITLE
Allow either v2 or v3 of zend-stdlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "zendframework/zend-escaper": "^2.5",
-        "zendframework/zend-stdlib": "^3.0"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",


### PR DESCRIPTION
Functionality used is ArrayUtils::merge, which has no changes between the two versions.

Fixes #12
