### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/tag-cloud.md
+++ b/doc/book/tag-cloud.md
@@ -242,7 +242,7 @@ $cloud = new Zend\Tag\Cloud([
 echo $cloud;
 ```
 
-The ouput:
+The output:
 
 ```php
 <ul class="my_custom_class" id="tag-cloud"><li><a href="/tag/code" style="font-size:


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.